### PR TITLE
Update enums for VitaDex

### DIFF
--- a/app/api/analyzeScan/route.ts
+++ b/app/api/analyzeScan/route.ts
@@ -62,14 +62,45 @@ export async function POST(req: Request) {
           properties: {
             nom_commun: { type: 'string' },
             nom_scientifique: { type: 'string' },
-            categorie: { type: 'string', enum: ['Oiseau','Mammifère','Insecte','Plante','Reptile','Amphibien','Poisson','Fongus','Autre'] },
-            biome: { type: 'string', enum: ['Forêt','Désert','Marin','Urbain','Cosmopolite','Montagne','Prairie','Eau douce','Toundra'] },
+            categorie: {
+              type: 'string',
+              enum: [
+                'Mammifère',
+                'Oiseau',
+                'Reptile',
+                'Amphibien',
+                'Poisson',
+                'Insecte',
+                'Arachnide',
+                'Mollusque',
+                'Crustacé',
+                'Plante',
+                'Champignon'
+              ]
+            },
+            biome: {
+              type: 'string',
+              enum: [
+                'Forêt',
+                'Savane/Prairie',
+                'Désert',
+                'Montagne/Rocheux',
+                'Eau douce',
+                'Milieu marin',
+                'Souterrain/Caverne',
+                'Urbain',
+                'Toundra/Polaire'
+              ]
+            },
             continent: { type: 'string' },
             traits: { type: 'array', items: { type: 'string' }, minItems: 4, maxItems: 4 },
             taille_moyenne: { type: 'string' },
             esperance_vie: { type: 'string' },
             description_professionnelle: { type: 'string' },
-            niveau_de_rarete: { type: 'string', enum: ['Commun','Peu commun','Rare','Très rare','Exceptionnel'] },
+            niveau_de_rarete: {
+              type: 'string',
+              enum: ['Commune', 'Peu commune', 'Rare', 'Légendaire']
+            },
             html_card: { type: 'string' }
           },
           required: ['nom_commun','nom_scientifique','categorie','biome','continent','traits','taille_moyenne','esperance_vie','description_professionnelle','niveau_de_rarete','html_card']
@@ -112,16 +143,26 @@ export async function POST(req: Request) {
     }
 
     // helper pour mapper continent en style pour DALL·E
-    const continent_style = (c: string) => {
-      switch (c) {
-        case 'Europe': return 'elegant watercolor';
-        case 'Amérique Nord': return '19th-century botanical';
-        case 'Afrique': return 'warm earthy tones';
-        case 'Asie': return 'minimal ink lines';
-        case 'Océanie': return 'vivid marine palette';
-        default: return 'fantasy naturalist';
-      }
-    };
+      const continent_style = (c: string) => {
+        switch (c) {
+          case 'Afrique':
+            return 'warm earthy tones';
+          case 'Europe':
+            return 'elegant watercolor';
+          case 'Asie':
+            return 'minimal ink lines';
+          case 'Amérique du Nord':
+            return '19th-century botanical';
+          case 'Amérique du Sud':
+            return 'lush rainforest palette';
+          case 'Océanie':
+            return 'vivid marine palette';
+          case 'Antarctique':
+            return 'icy desaturated hues';
+          default:
+            return 'fantasy naturalist';
+        }
+      };
 
     // Étape 2a : génération de l'arrière-plan via DALL·E
     const style = continent_style(metadata.continent);

--- a/lib/prompts.ts
+++ b/lib/prompts.ts
@@ -1,10 +1,19 @@
 export const Prompt1 = `
-Tu es biologiste ET intégrateur front-end VitaDex.
+Tu es biologiste et intégrateur front-end pour VitaDex.
 À partir des coordonnées latitude et longitude fournies, détermine le continent.
-Si l'espèce n'existe pas encore sur ce continent :
-  – extrais les données naturalistes (schéma JSON ci-dessous),
-  – renvoie aussi html_card = template rempli (une seule ligne),
-  – réponds uniquement via la fonction spec_extract.
+Si l'espèce n'existe pas encore dans la base :
+  – renvoie un JSON pour \`spec_extract\` avec les champs :
+    nom_commun, nom_scientifique,
+    categorie (Mammifère|Oiseau|Reptile|Amphibien|Poisson|Insecte|Arachnide|Mollusque|Crustacé|Plante|Champignon),
+    biome (Forêt|Savane/Prairie|Désert|Montagne/Rocheux|Eau douce|Milieu marin|Souterrain/Caverne|Urbain|Toundra/Polaire),
+    traits (4 valeurs libres),
+    taille_moyenne,
+    esperance_vie,
+    description_professionnelle,
+    niveau_de_rarete (Commune|Peu commune|Rare|Légendaire),
+    continent,
+    html_card.
+  – la réponse doit uniquement invoquer la fonction \`spec_extract\`.
 `;
 
 export const Prompt2 = `


### PR DESCRIPTION
## Summary
- update system prompt with canonical VitaDex lists
- sync analyzeScan API enum values with VitaDex spec
- expand continent to style mapping for DALL·E

## Testing
- `npm run build` *(fails: `next` not found)*
- `npm install` *(fails: npm exit handler never called)*